### PR TITLE
Toxic gas revamp + shader pausing

### DIFF
--- a/assets/materials/toxic_gas_volume.tres
+++ b/assets/materials/toxic_gas_volume.tres
@@ -5,11 +5,11 @@
 [resource]
 shader = ExtResource("1_wxmra")
 shader_parameter/base_color = Color(0.64700496, 0.9685002, 0.58258337, 1)
-shader_parameter/blend_mode = 8
-shader_parameter/posterize_steps = 14.0
+shader_parameter/blend_mode = 9
+shader_parameter/posterize_steps = 16.0
 shader_parameter/intensity = 1.0
 shader_parameter/falloff_pixels = 8.0
 shader_parameter/noise_scale = Vector2(3.2, 1.8)
-shader_parameter/noise_time_factors = Vector3(0.05, -0.05, 0.1)
-shader_parameter/noise_bias_low = -0.4
+shader_parameter/noise_time_factors = Vector3(0.05, -0.05, 0.03)
+shader_parameter/noise_bias_low = -0.5
 shader_parameter/noise_bias_high = 1.0

--- a/assets/materials/toxic_gas_volume.tres
+++ b/assets/materials/toxic_gas_volume.tres
@@ -1,0 +1,15 @@
+[gd_resource type="ShaderMaterial" format=3 uid="uid://c0mg78cg1eirn"]
+
+[ext_resource type="Shader" uid="uid://babaixpndqh1g" path="res://assets/shaders/ToxicGasVolume.gdshader" id="1_wxmra"]
+
+[resource]
+shader = ExtResource("1_wxmra")
+shader_parameter/base_color = Color(0.64700496, 0.9685002, 0.58258337, 1)
+shader_parameter/blend_mode = 8
+shader_parameter/posterize_steps = 14.0
+shader_parameter/intensity = 1.0
+shader_parameter/falloff_pixels = 8.0
+shader_parameter/noise_scale = Vector2(3.2, 1.8)
+shader_parameter/noise_time_factors = Vector3(0.05, -0.05, 0.1)
+shader_parameter/noise_bias_low = -0.4
+shader_parameter/noise_bias_high = 1.0

--- a/assets/shaders/FluidFlow.gdshader
+++ b/assets/shaders/FluidFlow.gdshader
@@ -5,6 +5,7 @@ shader_type canvas_item;
 
 // Globals
 global uniform ivec2 SCREEN_SIZE_PIXELS;
+global uniform float QUANTIZED_TIME = 0.0;
 
 // Basic settings
 group_uniforms BasicSettings;
@@ -218,7 +219,7 @@ void fragment() {
     float pixel_y = UV.y * float(flow_extent);
 
     // Time quantized to animation framerate
-    float qtime = round(TIME * float(framerate)) / float(framerate);
+    float qtime = QUANTIZED_TIME;
 
     // If this pixel is not in the flow area, draw nothing
     if (col < 0 || col > 15 || pixel_y < flow_start || pixel_y > dist + flow_falloff_bottom) {
@@ -280,7 +281,7 @@ void fragment() {
 
     // Apply screen refraction
     if (COLOR.a > 0.0 && !is_outline) {
-        float wave = sin(TIME * refract_timescale + round(pixel_y + 0.5) * refract_frequency);
+        float wave = sin(qtime * refract_timescale + round(pixel_y + 0.5) * refract_frequency);
         vec2 pixel_offset = vec2(float(wave * refract_strength * COLOR.a), 0.0); // Include a factor of alpha to fade smoothly at the falloff
 
         // Include the displacement in the refraction offset

--- a/assets/shaders/FluidFlow.gdshader
+++ b/assets/shaders/FluidFlow.gdshader
@@ -137,7 +137,7 @@ vec4 get_part_color(int col, float pixel_y, float dist, vec2 screen_uv, float qt
         return vec4(0.0);
     }
 
-    int frame_index = int(TIME * float(framerate)) % frame_count;
+    int frame_index = 0;  // TODO: remove frame count shenanigans; we don't actually use this anymore
 
     float frame_v = float(frame_index) / float(frame_count);
     float local_v = fract(pixel_y / 16.0) / float(frame_count);

--- a/assets/shaders/FluidFlow.gdshader
+++ b/assets/shaders/FluidFlow.gdshader
@@ -12,7 +12,6 @@ group_uniforms BasicSettings;
 uniform sampler2D fluid_tex : filter_nearest, repeat_enable;          // The fluid texture to sample
 uniform float base_opacity = 0.8;                                     // The base opacity of the fluid, before applying flow distance falloff
 uniform int flow_extent = 256;                                        // The extent of the flow texture in pixels, for calculating pixel UVs
-uniform int framerate = 12;                                           // The framerate of the fluid animation (frames per second)
 uniform int frame_count = 16;                                         // The total number of frames in the texture
 uniform float outline_threshold = 0.0;                                // Max value of max(r,g,b) to be considered outline (no refraction)
 uniform float flow_falloff_top = 8.0;                                 // How many pixels from the top to start fading out

--- a/assets/shaders/FluidVolume.gdshader
+++ b/assets/shaders/FluidVolume.gdshader
@@ -5,6 +5,7 @@ shader_type canvas_item;
 
 // Globals
 global uniform ivec2 SCREEN_SIZE_PIXELS;
+global uniform float QUANTIZED_TIME = 0.0;
 
 // Basic settings
 group_uniforms BasicSettings;
@@ -153,7 +154,7 @@ void fragment() {
     vec2 screen_pixel_coords = floor(SCREEN_UV * vec2(SCREEN_SIZE_PIXELS));   // Quantized screen coordinates of the pixel we're drawing
     vec2 pixel_coords = get_pixel_coords(UV);                                 // Pixel coordinates of the pixel we're drawing
     vec2 pixel_uv = get_pixel_uv(UV);                                         // UV coordinates of the pixel we're drawing, with v=0 at the bottom and v=1 at the top
-    float qtime = round(TIME * float(framerate)) / float(framerate);          // Time quantized to animation framerate
+    float qtime = QUANTIZED_TIME;
 
     // If outside the fluid area, don't draw anything
     if (!in_fluid_area(pixel_coords)) discard;

--- a/assets/shaders/FluidVolume.gdshader
+++ b/assets/shaders/FluidVolume.gdshader
@@ -11,7 +11,6 @@ global uniform float QUANTIZED_TIME = 0.0;
 group_uniforms BasicSettings;
 uniform vec4 base_color: source_color = vec4(0.2, 0.4, 0.8, 0.8);   // The base color of the fluid, before applying flow texture or lighting
 uniform vec4 outline_color: source_color = vec4(0.0);               // The color to use for the outline
-uniform int framerate = 12;                                         // The framerate of the fluid animation (frames per second)
 
 // Wave settings
 group_uniforms Waves;

--- a/assets/shaders/ToxicGasVolume.gdshader
+++ b/assets/shaders/ToxicGasVolume.gdshader
@@ -32,14 +32,12 @@ vec2 get_pixel_uv(vec2 uv) {
 }
 
 void fragment() {
-    vec2 screen_pixel_coords = floor(SCREEN_UV * vec2(SCREEN_SIZE_PIXELS));   // Quantized screen coordinates of the pixel we're drawing
-    vec2 screen_pixel_uv = screen_pixel_coords / vec2(SCREEN_SIZE_PIXELS);    // Quantized screen UV
-    vec2 pixel_coords = get_pixel_coords(UV);                                 // Pixel coordinates of the pixel we're drawing
-    vec2 pixel_uv = get_pixel_uv(UV);                                         // UV coordinates of the pixel we're drawing, with v=0 at the bottom and v=1 at the top
+    vec2 pixel_coords = get_pixel_coords(UV);   // Pixel coordinates of the pixel we're drawing
+    vec2 pixel_uv = get_pixel_uv(UV);           // UV coordinates of the pixel we're drawing, with v=0 at the bottom and v=1 at the top
 
     vec2 inverse_edge_distance = vec2(
-        1.0 - min(min(pixel_coords.x, area_size.x - pixel_coords.x), falloff_pixels) / falloff_pixels,
-        1.0 - min(min(pixel_coords.y, area_size.y - pixel_coords.y), falloff_pixels) / falloff_pixels);
+        1.0 - min(min(pixel_coords.x, area_size.x - 1.0 - pixel_coords.x), falloff_pixels) / falloff_pixels,
+        1.0 - min(min(pixel_coords.y, area_size.y - 1.0 - pixel_coords.y), falloff_pixels) / falloff_pixels);
     float edge_falloff = max(0.0, 1.0 - length(inverse_edge_distance));
 
     vec3 noise_uv = vec3(pixel_uv * noise_scale, 0.0) + (noise_time_factors * QUANTIZED_TIME);
@@ -48,4 +46,5 @@ void fragment() {
     vec4 screen_color = texture(screen_tex, SCREEN_UV);
     vec4 gas_color = vec4(base_color.rgb, base_color.a * noise_value * edge_falloff);        // Modulate alpha by noise value
     COLOR.rgb = blend(blend_mode, screen_color.rgb, gas_color.rgb, floor(gas_color.a * posterize_steps) / posterize_steps * intensity);
+    COLOR.a = 1.0;
 }

--- a/assets/shaders/ToxicGasVolume.gdshader
+++ b/assets/shaders/ToxicGasVolume.gdshader
@@ -1,0 +1,51 @@
+shader_type canvas_item;
+
+#include "res://assets/shaders/includes/noise.gdshaderinc"
+#include "res://assets/shaders/includes/blending.gdshaderinc"
+
+global uniform ivec2 SCREEN_SIZE_PIXELS;
+global uniform float QUANTIZED_TIME = 0.0;
+
+uniform vec4 base_color : source_color = vec4(0.5, 1.0, 0.5, 0.5);    // Base color for the gas with alpha
+uniform int blend_mode : hint_blend_mode = 1;                         // Blending mode for the gas
+uniform float posterize_steps = 6.0;                                  // Number of steps to posterize the gas alpha into
+uniform float intensity = 1.0;                                        // Intensity multiplier for the gas blend
+uniform float falloff_pixels = 8.0;                                   // How many pixels from the edge to start fading out the gas
+
+uniform vec2 noise_scale = vec2(1.0, 1.0);                            // Scale of the noise pattern in xyz
+uniform vec3 noise_time_factors = vec3(0.0, 0.0, 1.0);                // How much to offset by time in each dimension
+uniform float noise_bias_low = 0.3;                                   // Where to start fading noise from 0 to 1
+uniform float noise_bias_high = 0.7;                                  // Where to stop fading noise from 0 to 1
+
+uniform sampler2D screen_tex : hint_screen_texture, filter_nearest;   // Screen texture provided by Godot
+instance uniform vec2 area_size = vec2(32, 32);                       // Size of the area in pixels
+
+// Gets the floored coordinates of the pixel we're drawing
+vec2 get_pixel_coords(vec2 uv) {
+    return floor((uv * vec2(1.0, -1.0) + vec2(0.0, 1.0)) * area_size);
+}
+
+// Gets the floored UV coordinates of the pixel we're drawing
+// We reinterpret such that v=0 is at the bottom and v=1 is the top
+vec2 get_pixel_uv(vec2 uv) {
+    return get_pixel_coords(uv) / area_size;
+}
+
+void fragment() {
+    vec2 screen_pixel_coords = floor(SCREEN_UV * vec2(SCREEN_SIZE_PIXELS));   // Quantized screen coordinates of the pixel we're drawing
+    vec2 screen_pixel_uv = screen_pixel_coords / vec2(SCREEN_SIZE_PIXELS);    // Quantized screen UV
+    vec2 pixel_coords = get_pixel_coords(UV);                                 // Pixel coordinates of the pixel we're drawing
+    vec2 pixel_uv = get_pixel_uv(UV);                                         // UV coordinates of the pixel we're drawing, with v=0 at the bottom and v=1 at the top
+
+    vec2 inverse_edge_distance = vec2(
+        1.0 - min(min(pixel_coords.x, area_size.x - pixel_coords.x), falloff_pixels) / falloff_pixels,
+        1.0 - min(min(pixel_coords.y, area_size.y - pixel_coords.y), falloff_pixels) / falloff_pixels);
+    float edge_falloff = max(0.0, 1.0 - length(inverse_edge_distance));
+
+    vec3 noise_uv = vec3(pixel_uv * noise_scale, 0.0) + (noise_time_factors * QUANTIZED_TIME);
+    float noise_value = smoothstep(noise_bias_low, noise_bias_high, snoise(noise_uv));
+
+    vec4 screen_color = texture(screen_tex, SCREEN_UV);
+    vec4 gas_color = vec4(base_color.rgb, base_color.a * noise_value * edge_falloff);        // Modulate alpha by noise value
+    COLOR.rgb = blend(blend_mode, screen_color.rgb, gas_color.rgb, floor(gas_color.a * posterize_steps) / posterize_steps * intensity);
+}

--- a/assets/shaders/ToxicGasVolume.gdshader.uid
+++ b/assets/shaders/ToxicGasVolume.gdshader.uid
@@ -1,0 +1,1 @@
+uid://babaixpndqh1g

--- a/components/ToxicGas/ToxicGas.gd
+++ b/components/ToxicGas/ToxicGas.gd
@@ -1,0 +1,8 @@
+extends Area2D
+
+func killPenny(candidate: Node):
+	if(candidate is Penny):
+		candidate.die()
+
+func _ready():
+	body_entered.connect(killPenny)

--- a/components/ToxicGas/ToxicGas.gd
+++ b/components/ToxicGas/ToxicGas.gd
@@ -1,4 +1,13 @@
+@tool
 extends Area2D
+
+@onready var collision_shape: CollisionShape2D = $CollisionShape2D
+@onready var color_rect: ColorRect = $ColorRect
+
+@export var area_size: Vector2i = Vector2i(32, 32) :
+	set(value):
+		area_size = value
+		_updateSizes()
 
 func killPenny(candidate: Node):
 	if(candidate is Penny):
@@ -6,3 +15,18 @@ func killPenny(candidate: Node):
 
 func _ready():
 	body_entered.connect(killPenny)
+	_updateSizes()
+
+func _updateSizes():
+	if not is_node_ready():
+		return
+
+	# Update the collision shape size
+	collision_shape.shape.size = area_size * 2
+
+	# Update the color rect size
+	color_rect.size = area_size * 2
+	color_rect.position = -area_size
+
+	# Tell the shader the new area size for proper noise scaling
+	color_rect.set_instance_shader_parameter("area_size", Vector2(area_size) * 2.0)

--- a/components/ToxicGas/ToxicGas.gd.uid
+++ b/components/ToxicGas/ToxicGas.gd.uid
@@ -1,0 +1,1 @@
+uid://p1puvwlpd7gg

--- a/components/ToxicGas/ToxicGas.tscn
+++ b/components/ToxicGas/ToxicGas.tscn
@@ -1,0 +1,15 @@
+[gd_scene format=3 uid="uid://yca8b2k8wq6x"]
+
+[ext_resource type="Texture2D" uid="uid://dhvqn2n1fdqk7" path="res://assets/skeleton.png" id="1_yyiac"]
+
+[sub_resource type="RectangleShape2D" id="RectangleShape2D_2foi4"]
+
+[node name="ToxicGas" type="Area2D" unique_id=1311772067]
+
+[node name="Sprite2D" type="Sprite2D" parent="." unique_id=98686393]
+position = Vector2(-4.7683716e-07, -3.427267e-07)
+scale = Vector2(1.25, 1.0526315)
+texture = ExtResource("1_yyiac")
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="." unique_id=999086715]
+shape = SubResource("RectangleShape2D_2foi4")

--- a/components/ToxicGas/ToxicGas.tscn
+++ b/components/ToxicGas/ToxicGas.tscn
@@ -1,17 +1,21 @@
 [gd_scene format=3 uid="uid://yca8b2k8wq6x"]
 
 [ext_resource type="Script" uid="uid://p1puvwlpd7gg" path="res://components/ToxicGas/ToxicGas.gd" id="1_2foi4"]
-[ext_resource type="Texture2D" uid="uid://dhvqn2n1fdqk7" path="res://assets/skeleton.png" id="1_yyiac"]
+[ext_resource type="Material" uid="uid://c0mg78cg1eirn" path="res://assets/materials/toxic_gas_volume.tres" id="2_2foi4"]
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_2foi4"]
+resource_local_to_scene = true
+size = Vector2(32, 32)
 
 [node name="ToxicGas" type="Area2D" unique_id=1311772067]
 script = ExtResource("1_2foi4")
 
-[node name="Sprite2D" type="Sprite2D" parent="." unique_id=98686393]
-position = Vector2(-4.7683716e-07, -3.427267e-07)
-scale = Vector2(1.25, 1.0526315)
-texture = ExtResource("1_yyiac")
-
 [node name="CollisionShape2D" type="CollisionShape2D" parent="." unique_id=999086715]
 shape = SubResource("RectangleShape2D_2foi4")
+
+[node name="ColorRect" type="ColorRect" parent="." unique_id=938840937]
+material = ExtResource("2_2foi4")
+offset_left = -16.0
+offset_top = -16.0
+offset_right = 16.0
+offset_bottom = 16.0

--- a/components/ToxicGas/ToxicGas.tscn
+++ b/components/ToxicGas/ToxicGas.tscn
@@ -1,10 +1,12 @@
 [gd_scene format=3 uid="uid://yca8b2k8wq6x"]
 
+[ext_resource type="Script" uid="uid://p1puvwlpd7gg" path="res://components/ToxicGas/ToxicGas.gd" id="1_2foi4"]
 [ext_resource type="Texture2D" uid="uid://dhvqn2n1fdqk7" path="res://assets/skeleton.png" id="1_yyiac"]
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_2foi4"]
 
 [node name="ToxicGas" type="Area2D" unique_id=1311772067]
+script = ExtResource("1_2foi4")
 
 [node name="Sprite2D" type="Sprite2D" parent="." unique_id=98686393]
 position = Vector2(-4.7683716e-07, -3.427267e-07)

--- a/components/Utils/ShaderTimeManager.gd
+++ b/components/Utils/ShaderTimeManager.gd
@@ -1,6 +1,6 @@
 extends Node2D
 
-var FRAMERATE: float = 12.0
+const FRAMERATE: float = 12.0
 var _time_offset: float = 0
 
 func _ready() -> void:

--- a/components/Utils/ShaderTimeManager.gd
+++ b/components/Utils/ShaderTimeManager.gd
@@ -1,0 +1,19 @@
+extends Node2D
+
+var FRAMERATE: float = 12.0
+var _time_offset: float = 0
+
+func _process(delta: float) -> void:
+	# Update QUANTIZED_TIME for all shaders that need frame time
+
+	# If the game is paused, we don't update the frame time
+	# We do, however, update _time_offset so that when we resume the frame time will be correct
+	if SceneManager.is_paused:
+		_time_offset += delta
+		return
+
+	# Otherwise, figure out the current frame time and update the shader parameter
+	var effective_time = Time.get_ticks_msec() / 1000.0 - _time_offset
+
+	var quantized_time = floor(effective_time * FRAMERATE) / FRAMERATE
+	RenderingServer.global_shader_parameter_set("QUANTIZED_TIME", quantized_time)

--- a/components/Utils/ShaderTimeManager.gd
+++ b/components/Utils/ShaderTimeManager.gd
@@ -3,6 +3,9 @@ extends Node2D
 var FRAMERATE: float = 12.0
 var _time_offset: float = 0
 
+func _ready() -> void:
+	process_mode = Node.PROCESS_MODE_ALWAYS
+
 func _process(delta: float) -> void:
 	# Update QUANTIZED_TIME for all shaders that need frame time
 

--- a/components/Utils/ShaderTimeManager.gd.uid
+++ b/components/Utils/ShaderTimeManager.gd.uid
@@ -1,0 +1,1 @@
+uid://cwk203l2hosxx

--- a/levels/ToxicGasTest.tscn
+++ b/levels/ToxicGasTest.tscn
@@ -1,0 +1,88 @@
+[gd_scene format=4 uid="uid://dl2tv3mfffx3j"]
+
+[ext_resource type="PackedScene" uid="uid://cuvwsherd1opx" path="res://components/Background/Background.tscn" id="1_g58o8"]
+[ext_resource type="Texture2D" uid="uid://t6ur05s1g4pw" path="res://assets/ground-tile.png" id="2_48hdd"]
+[ext_resource type="PackedScene" uid="uid://cuv0lsyon5bl" path="res://player/Player/Player.tscn" id="3_r3vea"]
+[ext_resource type="Script" uid="uid://c0ddx2m0mmo38" path="res://components/Spike/Spike.gd" id="4_cttde"]
+[ext_resource type="Texture2D" uid="uid://lersso2vpm10" path="res://assets/components/spike.png" id="5_nb8d4"]
+[ext_resource type="Script" uid="uid://bqfrci4605dyb" path="res://components/Spike/SpikeCollider/SpikeCollider.gd" id="6_05xqd"]
+[ext_resource type="PackedScene" uid="uid://c1ef0aj0ah215" path="res://components/ExitZone/ExitZone.tscn" id="7_to7pq"]
+[ext_resource type="PackedScene" uid="uid://yca8b2k8wq6x" path="res://components/ToxicGas/ToxicGas.tscn" id="8_48hdd"]
+
+[sub_resource type="TileSetAtlasSource" id="TileSetAtlasSource_av7kl"]
+texture = ExtResource("2_48hdd")
+0:0/0 = 0
+0:0/0/physics_layer_0/polygon_0/points = PackedVector2Array(-8, -8, 8, -8, 8, 8, -8, 8)
+1:0/0 = 0
+1:0/0/physics_layer_0/polygon_0/points = PackedVector2Array(-8, -8, 8, -8, 8, 8, -8, 8)
+2:0/0 = 0
+2:0/0/physics_layer_0/polygon_0/points = PackedVector2Array(-8, -8, 8, -8, 8, 8, -8, 8)
+3:0/0 = 0
+3:0/0/physics_layer_0/polygon_0/points = PackedVector2Array(-8, -8, 8, -8, 8, 8, -8, 8)
+0:1/0 = 0
+0:1/0/physics_layer_0/polygon_0/points = PackedVector2Array(-8, -8, 8, -8, 8, 8, -8, 8)
+1:1/0 = 0
+1:1/0/physics_layer_0/polygon_0/points = PackedVector2Array(-8, -8, 8, -8, 8, 8, -8, 8)
+2:1/0 = 0
+2:1/0/physics_layer_0/polygon_0/points = PackedVector2Array(-8, -8, 8, -8, 8, 8, -8, 8)
+3:1/0 = 0
+3:1/0/physics_layer_0/polygon_0/points = PackedVector2Array(-8, -8, 8, -8, 8, 8, -8, 8)
+0:2/0 = 0
+0:2/0/physics_layer_0/polygon_0/points = PackedVector2Array(-8, -8, 8, -8, 8, 8, -8, 8)
+1:2/0 = 0
+1:2/0/physics_layer_0/polygon_0/points = PackedVector2Array(-8, -8, 8, -8, 8, 8, -8, 8)
+2:2/0 = 0
+2:2/0/physics_layer_0/polygon_0/points = PackedVector2Array(-8, -8, 8, -8, 8, 8, -8, 8)
+3:2/0 = 0
+3:2/0/physics_layer_0/polygon_0/points = PackedVector2Array(-8, -8, 8, -8, 8, 8, -8, 8)
+0:3/0 = 0
+0:3/0/physics_layer_0/polygon_0/points = PackedVector2Array(-8, -8, 8, -8, 8, 8, -8, 8)
+1:3/0 = 0
+1:3/0/physics_layer_0/polygon_0/points = PackedVector2Array(-8, -8, 8, -8, 8, 8, -8, 8)
+2:3/0 = 0
+2:3/0/physics_layer_0/polygon_0/points = PackedVector2Array(-8, -8, 8, -8, 8, 8, -8, 8)
+3:3/0 = 0
+3:3/0/physics_layer_0/polygon_0/points = PackedVector2Array(-8, -8, 8, -8, 8, 8, -8, 8)
+
+[sub_resource type="TileSet" id="TileSet_muxx5"]
+physics_layer_0/collision_layer = 1
+terrain_set_0/mode = 0
+sources/0 = SubResource("TileSetAtlasSource_av7kl")
+
+[sub_resource type="RectangleShape2D" id="RectangleShape2D_6yh2b"]
+size = Vector2(8, 65)
+
+[node name="SpikeTest" type="Node2D" unique_id=816462362]
+
+[node name="Background" parent="." unique_id=2080776597 instance=ExtResource("1_g58o8")]
+
+[node name="TileMapLayer" type="TileMapLayer" parent="." unique_id=1016908615]
+position = Vector2(225, 160)
+tile_map_data = PackedByteArray("AAD9/wAAAAABAAAAAAD+/wAAAAABAAAAAAD//wAAAAABAAAAAAAAAAAAAAABAAAAAAABAAAAAAABAAAAAAACAAAAAAABAAAAAAABAAEAAAABAAIAAAD//wEAAAABAAIAAAAAAAEAAAABAAIAAAD+/wEAAAABAAIAAAD9/wEAAAABAAIAAAADAAEAAAACAAIAAAADAAAAAAACAAAAAAACAAEAAAABAAIAAAD8/wAAAAAAAAAAAAD8/wEAAAAAAAIAAAABAPv/AAADAAMAAAAAAP//AAABAAAAAAACAP//AAABAAAAAAA=")
+tile_set = SubResource("TileSet_muxx5")
+
+[node name="Player" parent="TileMapLayer" unique_id=1162088554 instance=ExtResource("3_r3vea")]
+position = Vector2(0, -31)
+
+[node name="Spike" type="RigidBody2D" parent="TileMapLayer" unique_id=585998066]
+position = Vector2(24, -61)
+script = ExtResource("4_cttde")
+
+[node name="CollisionPolygon2D" type="CollisionPolygon2D" parent="TileMapLayer/Spike" unique_id=1522893824]
+polygon = PackedVector2Array(-4, -3, 4, -3, 0, 4)
+
+[node name="Sprite2D" type="Sprite2D" parent="TileMapLayer/Spike" unique_id=768931425]
+texture = ExtResource("5_nb8d4")
+
+[node name="Area2D" type="Area2D" parent="TileMapLayer/Spike" unique_id=1991308729]
+script = ExtResource("6_05xqd")
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="TileMapLayer/Spike/Area2D" unique_id=312434216]
+position = Vector2(0, 28.5)
+shape = SubResource("RectangleShape2D_6yh2b")
+
+[node name="ExitZone" parent="TileMapLayer" unique_id=1439884645 instance=ExtResource("7_to7pq")]
+position = Vector2(-53, -10)
+
+[node name="ToxicGas" parent="." unique_id=1311772067 instance=ExtResource("8_48hdd")]
+position = Vector2(195, 138)

--- a/levels/ToxicGasTest.tscn
+++ b/levels/ToxicGasTest.tscn
@@ -57,6 +57,7 @@ size = Vector2(8, 65)
 [node name="Background" parent="." unique_id=2080776597 instance=ExtResource("1_g58o8")]
 
 [node name="TileMapLayer" type="TileMapLayer" parent="." unique_id=1016908615]
+z_index = 3
 position = Vector2(225, 160)
 tile_map_data = PackedByteArray("AAD9/wAAAAABAAAAAAD+/wAAAAABAAAAAAD//wAAAAABAAAAAAAAAAAAAAABAAAAAAABAAAAAAABAAAAAAACAAAAAAABAAAAAAABAAEAAAABAAIAAAD//wEAAAABAAIAAAAAAAEAAAABAAIAAAD+/wEAAAABAAIAAAD9/wEAAAABAAIAAAADAAEAAAACAAIAAAADAAAAAAACAAAAAAACAAEAAAABAAIAAAD8/wAAAAAAAAAAAAD8/wEAAAAAAAIAAAABAPv/AAADAAMAAAAAAP//AAABAAAAAAACAP//AAABAAAAAAA=")
 tile_set = SubResource("TileSet_muxx5")
@@ -82,7 +83,9 @@ position = Vector2(0, 28.5)
 shape = SubResource("RectangleShape2D_6yh2b")
 
 [node name="ExitZone" parent="TileMapLayer" unique_id=1439884645 instance=ExtResource("7_to7pq")]
-position = Vector2(-53, -10)
+position = Vector2(70, -16)
 
 [node name="ToxicGas" parent="." unique_id=1311772067 instance=ExtResource("8_48hdd")]
-position = Vector2(195, 138)
+z_index = 1
+position = Vector2(162, 139)
+area_size = Vector2i(47, 35)

--- a/project.godot
+++ b/project.godot
@@ -92,10 +92,6 @@ SCREEN_SIZE_PIXELS={
 "type": "ivec2",
 "value": Vector2i(512, 288)
 }
-FRAMERATE={
-"type": "int",
-"value": 12
-}
 QUANTIZED_TIME={
 "type": "float",
 "value": 0.0

--- a/project.godot
+++ b/project.godot
@@ -20,6 +20,7 @@ config/icon="uid://3e51eumu63ft"
 SceneManager="*uid://clwcou0lvoqt0"
 InputManager="*uid://bxqq0x5x18kd8"
 GameManager="*uid://dms3mbn4e8xh7"
+ShaderTimeManager="*uid://cwk203l2hosxx"
 TarManager="*uid://bi4gn4y2dllxn"
 
 [display]
@@ -90,4 +91,12 @@ textures/vram_compression/import_etc2_astc=true
 SCREEN_SIZE_PIXELS={
 "type": "ivec2",
 "value": Vector2i(512, 288)
+}
+FRAMERATE={
+"type": "int",
+"value": 12
+}
+QUANTIZED_TIME={
+"type": "float",
+"value": 0.0
 }


### PR DESCRIPTION
- Implement configurable toxic gas area sizes without needing to make them local
- Toxic gas shader + material for the gas volumes
- Implement global shader frame time that respects pausing
- Update fluid shaders with global frame time rather than computing frame time themselves